### PR TITLE
fix: replace SiOpenai with inline SVG — not exported by react-icons v5

### DIFF
--- a/src/pages/Usage.tsx
+++ b/src/pages/Usage.tsx
@@ -40,7 +40,7 @@ import accessibilityDocs from '../../docs/shared/accessibility.md?raw';
 import performanceDocs from '../../docs/shared/performance.md?raw';
 import troubleshootingDocs from '../../docs/shared/troubleshooting.md?raw';
 
-import { SiClaude, SiGithub, SiOpenai } from 'react-icons/si';
+import { SiClaude, SiGithub } from 'react-icons/si';
 
 const FRAMEWORKS = [
   { id: 'vanilla', label: 'Vanilla', icon: 'js', color: '#f7df1e' },
@@ -951,7 +951,7 @@ export default function UsagePage() {
                       className="w-full flex items-center justify-between px-4 py-2 text-[13px] text-text-base/70 hover:text-text-base hover:bg-text-base/4 transition-colors text-left cursor-pointer"
                     >
                       <span className="flex items-center gap-2">
-                        <SiOpenai size={14}></SiOpenai>
+                        <svg width={14} height={14} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08-4.778 2.758a.795.795 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" /></svg>
                         Open in ChatGPT
                       </span>
                       <re-icon icon="arrow-up-right2" size={12} className="text-text-base/30"></re-icon>


### PR DESCRIPTION
<!-- Thanks for contributing to Reicon! 💜 Fill out the relevant sections below. -->

## Summary

<!-- One sentence: what does this PR do? -->

## Related issue

<!-- Closes #123 — delete this line if not applicable -->

## Type of change

- [ ] 🎨 New icon(s)
- [ ] ✏️ Icon fix (alignment / stroke / grid)
- [x] 🐛 Bug fix
- [ ] ✨ Feature / enhancement
- [ ] 📖 Documentation
- [ ] 🔧 Chore / tooling

---

## For icon contributions

<!-- Fill this out if you checked "New icon(s)" or "Icon fix" above -->

**Icon name(s):** <!-- e.g. wave-hand, split-screen -->

**Did you add `"contributor": { "github": "your-username" }` to each new icon?**
- [ ] Yes — my GitHub username is in `data/icon-data.json` next to each new icon
- [ ] N/A — this is an icon fix, not a new icon

**Screenshots**

| Outline | Filled |
| ------- | ------ |
|         |        |

---

## Checklist

- [x] Branch is up to date with `main`.
- [x] `npm run sync:icons` was run after editing `data/icon-data.json`.
- [x] `npm run validate:icons` reports ✅ in sync.
- [x] `npm run lint` passes (no type errors).
- [x] Icons are on a 24×24 grid, use `currentColor`, paths are SVGO-optimised.
- [x] **I did NOT run `npm run build:packages`** — package releases are handled by the maintainer.
