### PR TITLE
feat: add reicon-mcp MCP server and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All icons are maintained in two weights:
 | <img src="https://cdn.simpleicons.org/svelte/FF3E00" alt="Svelte logo" width="30"> | **`reicon-svelte`** | [![npm](https://img.shields.io/npm/v/reicon-svelte?color=6C5CE7&label=)](https://www.npmjs.com/package/reicon-svelte) | ![npm downloads](https://img.shields.io/npm/dm/reicon-svelte?color=6C5CE7&label=) | [Guide](docs/svelte/usage.md) · [Source](./packages/reicon-svelte) |
 | <img src="./public/readme-assets/figma.svg" alt="Figma logo" width="28"> | **`reicon-figma`** | — | — | [Guide](docs/figma/usage.md) · [Source](./packages/reicon-figma) |
 | <img src="./public/readme-assets/vscode.svg" alt="VS Code logo" width="30"> | **`reicon-vscode`** | [![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/DevChauhan.reicon?color=6C5CE7&label=)](https://marketplace.visualstudio.com/items?itemName=DevChauhan.reicon) | — | [Guide](docs/vscode/usage.md) · [Source](./packages/reicon-vscode) |
+| <img src="https://cdn.simpleicons.org/modelcontextprotocol/6C5CE7" alt="MCP logo" width="30"> | **`reicon-mcp`** | — | — | [Guide](docs/mcp/usage.md) · [Source](./packages/reicon-mcp) |
 | <img src="./public/readme-assets/svg.svg" alt="SVG logo" width="30"> | **`reicon-svg`** | — | — | [Guide](docs/svg/usage.md) · [Download](./public/reicon-icons.zip) |
 
 

--- a/docs/mcp/usage.md
+++ b/docs/mcp/usage.md
@@ -1,0 +1,154 @@
+# Usage of Reicon MCP Server
+
+The `reicon-mcp` package exposes Reicon icons to AI agents and automation tools through the Model Context Protocol. Agents can search the icon library, inspect SVG markup, and generate copy-pasteable code snippets for React, Vue, Svelte, HTML, or raw SVG without human intervention.
+
+## What you can accomplish
+- Search 2,700+ icons by keyword with ranked results
+- Preview raw SVG markup before applying an icon
+- Generate framework-specific import and usage snippets
+- Browse icons by category
+- Run the same logic from a CLI for scripts and CI
+
+---
+
+## Installation
+
+Install from npm or build from the monorepo:
+
+```bash
+npm install reicon-mcp
+```
+
+From source:
+
+```bash
+git clone https://github.com/dqev/reicon.git
+cd reicon
+npm run build:mcp
+```
+
+---
+
+## MCP Configuration
+
+Add the server to your MCP client. With no arguments, `reicon-mcp` starts a stdio MCP server.
+
+```json
+{
+  "mcpServers": {
+    "reicon": {
+      "command": "npx",
+      "args": ["reicon-mcp"]
+    }
+  }
+}
+```
+
+For a local development build:
+
+```json
+{
+  "mcpServers": {
+    "reicon": {
+      "command": "node",
+      "args": ["./packages/reicon-mcp/bin/run.cjs"]
+    }
+  }
+}
+```
+
+---
+
+## Agent Workflow
+
+A typical two-step flow for an agent adding an icon to a React component:
+
+1. **Search** with concise keywords (not full sentences):
+
+```
+search_icons({ query: "heart", weight: "Filled" })
+```
+
+2. **Apply** the chosen icon:
+
+```
+apply_icon({
+  name: "heart",
+  weight: "Filled",
+  framework: "react",
+  size: 24,
+  color: "#ef4444"
+})
+```
+
+The tool returns `{ importStatement, usageSnippet }`. The agent uses its own file edit tools to insert the code.
+
+---
+
+## Tools Reference
+
+### search_icons
+
+Input: `{ query: string, weight?: "Outline" | "Filled", limit?: number }`
+
+Returns ranked results with `name`, `weight`, `category`, `tags`, and `score`. Queries that look like full sentences are rejected. Use short keywords like `cart`, `user`, or `settings`.
+
+### view_icon
+
+Input: `{ name: string, weight: "Outline" | "Filled" }`
+
+Returns the raw optimized SVG string plus `viewBox`, `tags`, and `category`.
+
+### apply_icon
+
+Input:
+
+```ts
+{
+  name: string;
+  weight: "Outline" | "Filled";
+  framework: "react" | "vue" | "svelte" | "html" | "svg";
+  size?: number;
+  color?: string;
+  componentName?: string;
+}
+```
+
+Defaults: `size` 24, `color` currentColor, `componentName` is PascalCase of the icon name.
+
+Returns `{ importStatement, usageSnippet }` matching the syntax in the React, Vue, Svelte, and CDN usage guides.
+
+### list_categories
+
+No input. Returns all distinct category values from the dataset.
+
+---
+
+## CLI Usage
+
+The same binary supports CLI mode when arguments are provided:
+
+```bash
+npx reicon-mcp search "shopping cart"
+npx reicon-mcp view heart --weight Filled
+npx reicon-mcp apply heart --framework react --size 32 --color "#ef4444"
+npx reicon-mcp categories
+```
+
+### Scripted file insertion
+
+For CI or scripts without an agent supervising edits:
+
+```bash
+npx reicon-mcp apply heart --framework react --file src/App.tsx --marker "{/* ICON */}"
+```
+
+This replaces the exact marker with the usage snippet and inserts the import at the top if missing. Exits non-zero if the marker is not found.
+
+---
+
+## Offline Operation
+
+The search index is bundled at build time from `data/icon-data.json`. No network calls are made at runtime. Once installed, the server works fully offline.
+
+> **Note:** Rebuild with `npm run build:mcp` after the icon dataset changes to refresh the bundled index.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "jszip": "^3.10.1",
         "lenis": "^1.3.23",
         "motion": "^12.40.0",
-        "posthog-node": "^5.34.6",
         "react": "^19.0.1",
         "react-colorful": "^5.7.0",
         "react-dom": "^19.0.1",
@@ -22,7 +21,6 @@
         "react-icons": "^5.6.0",
         "react-router-dom": "^7.6.0",
         "reicon-react": "^1.0.4",
-        "sharp": "^0.34.5",
         "vite": "^6.2.3"
       },
       "devDependencies": {
@@ -30,6 +28,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "autoprefixer": "^10.4.21",
+        "posthog-node": "^5.34.6",
         "tailwindcss": "^4.1.14",
         "typescript": "~5.8.2",
         "vite": "^6.2.3",
@@ -778,471 +777,6 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1292,6 +826,7 @@
       "version": "1.29.5",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.5.tgz",
       "integrity": "sha512-Jm5AE95EwBRqO6J8+skDufyf5rnEcmOvjYArCKCOzD4mWdH1xGpfcRXj5TEyZII3mD04Kr7pw9aP2ZbAHQGu2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@posthog/types": "1.374.2"
@@ -1301,6 +836,7 @@
       "version": "1.374.2",
       "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.374.2.tgz",
       "integrity": "sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2964,6 +2500,7 @@
       "version": "5.34.6",
       "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.34.6.tgz",
       "integrity": "sha512-oDjagFRkmCbWJBxG1FVU3kOGC6dxNpR849q8ARrZSBK3zWz4zJox6V5EjrATKM9RXKvAmbCSFoxYaOYTzp3phA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@posthog/core": "1.29.5"
@@ -3200,62 +2737,6 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3325,7 +2806,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build:figma": "node packages/reicon-figma/scripts/build.cjs",
     "build:svelte": "node packages/reicon-svelte/scripts/build.cjs",
     "build:vscode": "node packages/reicon-vscode/scripts/build.cjs",
-    "build:packages": "node scripts/sync-icon-names.mjs && npm run build:react && npm run build:react-native && npm run build:vue && npm run build:js && npm run build:cdn:min && npm run build:figma && npm run build:svelte && npm run build:vscode",
+    "build:mcp": "node packages/reicon-mcp/scripts/build.cjs",
+    "build:packages": "node scripts/sync-icon-names.mjs && npm run build:react && npm run build:react-native && npm run build:vue && npm run build:js && npm run build:cdn:min && npm run build:figma && npm run build:svelte && npm run build:vscode && npm run build:mcp",
     "preview": "vite preview",
     "clean": "rm -rf dist packages/*/dist",
     "lint": "tsc --noEmit"
@@ -44,6 +45,7 @@
     "vite": "^6.2.3"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "@types/node": "^22.14.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -52,6 +54,7 @@
     "tailwindcss": "^4.1.14",
     "typescript": "~5.8.2",
     "vite": "^6.2.3",
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "zod": "^3.24.0"
   }
 }

--- a/packages/README.md
+++ b/packages/README.md
@@ -19,6 +19,7 @@ This directory contains individual npm libraries and integration extension packa
 | [`reicon-svelte`](file:///Users/devchauhan/Documents/Website/reicon/packages/reicon-svelte) | Svelte Component Wrapper | `dist/` | `npm run build:svelte` |
 | [`reicon-figma`](file:///Users/devchauhan/Documents/Website/reicon/packages/reicon-figma) | Figma Plugin Web UI | `Reicon/ui.html` | `npm run build:figma` |
 | [`reicon-vscode`](file:///Users/devchauhan/Documents/Website/reicon/packages/reicon-vscode) | VS Code Intellisense Extension | `dist/ui.html` | `npm run build:vscode` |
+| [`reicon-mcp`](file:///Users/devchauhan/Documents/Website/reicon/packages/reicon-mcp) | MCP Server & CLI for Agents | `dist/` | `npm run build:mcp` |
 
 ## ⚙️ How Packaging Works
 

--- a/packages/reicon-mcp/.gitignore
+++ b/packages/reicon-mcp/.gitignore
@@ -1,0 +1,3 @@
+dist/
+src/data/icon-index.json
+node_modules/

--- a/packages/reicon-mcp/LICENSE
+++ b/packages/reicon-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dev Chauhan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/reicon-mcp/README.md
+++ b/packages/reicon-mcp/README.md
@@ -1,0 +1,69 @@
+# reicon-mcp
+
+MCP server and CLI for searching, previewing, and applying Reicon icons. Works fully offline with a prebuilt search index.
+
+## MCP Server
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "reicon": {
+      "command": "npx",
+      "args": ["reicon-mcp"]
+    }
+  }
+}
+```
+
+Or point directly at the local binary after building:
+
+```json
+{
+  "mcpServers": {
+    "reicon": {
+      "command": "node",
+      "args": ["/path/to/reicon/packages/reicon-mcp/bin/run.cjs"]
+    }
+  }
+}
+```
+
+### Tools
+
+| Tool | Description |
+| :--- | :--- |
+| `search_icons` | Rank icons by keyword |
+| `view_icon` | Return raw SVG markup and metadata |
+| `apply_icon` | Generate framework-specific import and usage snippets |
+| `list_categories` | List all icon categories |
+
+## CLI
+
+```bash
+npx reicon-mcp search "shopping cart"
+npx reicon-mcp view heart --weight Filled
+npx reicon-mcp apply heart --framework react --size 32 --color "#ef4444"
+npx reicon-mcp categories
+```
+
+### File write mode
+
+For scripted insertion, replace a marker string in a target file:
+
+```bash
+npx reicon-mcp apply heart --framework react --file src/App.tsx --marker "{/* ICON */}"
+```
+
+The marker must exist exactly once. The command exits non-zero if the marker is not found.
+
+## Build
+
+From the monorepo root:
+
+```bash
+npm run build:mcp
+```
+
+MIT © [Dev Chauhan](https://devchauhan.in)

--- a/packages/reicon-mcp/bin/run.cjs
+++ b/packages/reicon-mcp/bin/run.cjs
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
 
+const { existsSync } = require('fs');
+const { join } = require('path');
+const { pathToFileURL } = require('url');
+
 const args = process.argv.slice(2);
+const root = join(__dirname, '..');
+const base = existsSync(join(root, 'server', 'index.js')) ? root : join(root, 'dist');
 
 if (args.length === 0) {
-  import('../dist/server/index.js');
+  import(pathToFileURL(join(base, 'server/index.js')).href);
 } else {
-  import('../dist/cli/index.js').then((mod) => {
+  import(pathToFileURL(join(base, 'cli/index.js')).href).then((mod) => {
     mod.run(args).catch((err) => {
       console.error(err);
       process.exit(1);

--- a/packages/reicon-mcp/bin/run.cjs
+++ b/packages/reicon-mcp/bin/run.cjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+  import('../dist/server/index.js');
+} else {
+  import('../dist/cli/index.js').then((mod) => {
+    mod.run(args).catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+  });
+}

--- a/packages/reicon-mcp/package.json
+++ b/packages/reicon-mcp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "reicon-mcp",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP server and CLI for browsing and applying Reicon icons.",
+  "bin": {
+    "reicon-mcp": "bin/run.cjs"
+  },
+  "scripts": {
+    "build": "node scripts/build.cjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/packages/reicon-mcp/scripts/build.cjs
+++ b/packages/reicon-mcp/scripts/build.cjs
@@ -107,7 +107,7 @@ const pkg = {
   bin: {
     'reicon-mcp': 'bin/run.cjs',
   },
-  main: './dist/server/index.js',
+  main: './server/index.js',
   files: ['bin', 'dist', 'README.md', 'LICENSE'],
   scripts: {
     build: 'node scripts/build.cjs',
@@ -137,5 +137,6 @@ fs.writeFileSync(path.join(ROOT, 'dist', 'package.json'), JSON.stringify(pkg, nu
 fs.copyFileSync(path.join(ROOT, 'README.md'), path.join(ROOT, 'dist', 'README.md'));
 fs.copyFileSync(path.join(ROOT, 'LICENSE'), path.join(ROOT, 'dist', 'LICENSE'));
 fs.cpSync(path.join(ROOT, 'bin'), path.join(ROOT, 'dist', 'bin'), { recursive: true });
+fs.chmodSync(path.join(ROOT, 'dist', 'bin', 'run.cjs'), 0o755);
 
 console.log('reicon-mcp build complete');

--- a/packages/reicon-mcp/scripts/build.cjs
+++ b/packages/reicon-mcp/scripts/build.cjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..');
+const DATA_PATH = path.join(__dirname, '..', '..', '..', 'data', 'icon-data.json');
+const INDEX_OUT = path.join(ROOT, 'src', 'data', 'icon-index.json');
+const DIST_DATA = path.join(ROOT, 'dist', 'data');
+const DIST_INDEX = path.join(DIST_DATA, 'icon-index.json');
+
+const SEARCH_ALIASES = {
+  x: ['close', 'dismiss', 'cancel'],
+  cart: ['shopping cart', 'shopping'],
+  trash: ['delete', 'remove', 'bin'],
+  settings: ['gear', 'cog'],
+  search: ['magnifier', 'find'],
+  user: ['profile', 'account', 'avatar'],
+  heart: ['love', 'favorite', 'like'],
+};
+
+function toPascalCase(str) {
+  return str
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+}
+
+function stripSvgWrapper(code) {
+  if (!code) return '';
+  return code.replace(/^<svg[^>]*>/, '').replace(/<\/svg>\s*$/, '').trim();
+}
+
+function rewriteColors(svg) {
+  return svg.replace(/fill="white"/g, 'fill="currentColor"');
+}
+
+function buildIndex(data) {
+  const icons = [];
+  const categorySet = new Set();
+  const pascalLowerSet = new Set();
+
+  for (const [catKey, catData] of Object.entries(data.categories || {})) {
+    categorySet.add(catKey);
+
+    for (const [iconKey, icon] of Object.entries(catData.icons || {})) {
+      let pascal = toPascalCase(iconKey);
+
+      if (pascalLowerSet.has(pascal.toLowerCase())) {
+        pascal += toPascalCase(catKey);
+      }
+      pascalLowerSet.add(pascal.toLowerCase());
+
+      const weights = {};
+
+      for (const wName of ['Outline', 'Filled']) {
+        const wData = icon.weights?.[wName];
+        if (wData?.code) {
+          weights[wName] = {
+            code: rewriteColors(stripSvgWrapper(wData.code)),
+            viewBox: '0 0 24 24',
+          };
+        }
+      }
+
+      if (Object.keys(weights).length > 0) {
+        icons.push({
+          name: iconKey,
+          pascal,
+          category: catKey,
+          tags: [...(icon.description || []), ...(SEARCH_ALIASES[iconKey] || [])],
+          weights,
+        });
+      }
+    }
+  }
+
+  icons.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    icons,
+    categories: [...categorySet].sort(),
+  };
+}
+
+console.log('Building reicon-mcp …');
+
+const data = JSON.parse(fs.readFileSync(DATA_PATH, 'utf-8'));
+const index = buildIndex(data);
+
+fs.mkdirSync(path.dirname(INDEX_OUT), { recursive: true });
+fs.writeFileSync(INDEX_OUT, JSON.stringify(index) + '\n');
+
+fs.mkdirSync(DIST_DATA, { recursive: true });
+fs.copyFileSync(INDEX_OUT, DIST_INDEX);
+
+console.log(`Wrote ${index.icons.length} icons to icon-index.json`);
+
+execSync('node ../../node_modules/typescript/bin/tsc -p tsconfig.json', { cwd: ROOT, stdio: 'inherit' });
+
+const pkg = {
+  name: 'reicon-mcp',
+  version: '1.0.0',
+  type: 'module',
+  description: 'MCP server and CLI for browsing and applying Reicon icons.',
+  bin: {
+    'reicon-mcp': 'bin/run.cjs',
+  },
+  main: './dist/server/index.js',
+  files: ['bin', 'dist', 'README.md', 'LICENSE'],
+  scripts: {
+    build: 'node scripts/build.cjs',
+  },
+  keywords: ['reicon', 'icons', 'mcp', 'model-context-protocol', 'svg'],
+  author: 'Dev Chauhan',
+  license: 'MIT',
+  repository: {
+    type: 'git',
+    url: 'https://github.com/dqev/reicon.git',
+    directory: 'packages/reicon-mcp',
+  },
+  homepage: 'https://reicon.dev',
+  bugs: {
+    url: 'https://github.com/dqev/reicon/issues',
+  },
+  dependencies: {
+    '@modelcontextprotocol/sdk': '^1.12.0',
+    'zod': '^3.24.0',
+  },
+  engines: {
+    node: '>=18',
+  },
+};
+
+fs.writeFileSync(path.join(ROOT, 'dist', 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
+fs.copyFileSync(path.join(ROOT, 'README.md'), path.join(ROOT, 'dist', 'README.md'));
+fs.copyFileSync(path.join(ROOT, 'LICENSE'), path.join(ROOT, 'dist', 'LICENSE'));
+fs.cpSync(path.join(ROOT, 'bin'), path.join(ROOT, 'dist', 'bin'), { recursive: true });
+
+console.log('reicon-mcp build complete');

--- a/packages/reicon-mcp/scripts/build.cjs
+++ b/packages/reicon-mcp/scripts/build.cjs
@@ -108,7 +108,7 @@ const pkg = {
     'reicon-mcp': 'bin/run.cjs',
   },
   main: './server/index.js',
-  files: ['bin', 'dist', 'README.md', 'LICENSE'],
+  files: ['bin', 'cli', 'server', 'core', 'data', 'README.md', 'LICENSE'],
   scripts: {
     build: 'node scripts/build.cjs',
   },

--- a/packages/reicon-mcp/src/cli/index.ts
+++ b/packages/reicon-mcp/src/cli/index.ts
@@ -1,0 +1,141 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { handleApplyIcon } from '../server/tools/apply-icon.js';
+import { handleListCategories } from '../server/tools/list-categories.js';
+import { handleSearchIcons } from '../server/tools/search-icons.js';
+import { handleViewIcon } from '../server/tools/view-icon.js';
+import type { Framework, IconWeight } from '../core/types.js';
+
+function parseArgs(argv: string[]) {
+  const result: Record<string, string> = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        result[key] = next;
+        i++;
+      } else {
+        result[key] = 'true';
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { positional, flags: result };
+}
+
+function print(data: unknown) {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function applyToFile(
+  filePath: string,
+  marker: string,
+  importStatement: string,
+  usageSnippet: string,
+) {
+  const content = readFileSync(filePath, 'utf-8');
+  if (!content.includes(marker)) {
+    console.error(`Marker not found in ${filePath}: ${marker}`);
+    process.exit(1);
+  }
+
+  let updated = content.replace(marker, usageSnippet);
+
+  if (importStatement && !updated.includes(importStatement)) {
+    const lines = updated.split('\n');
+    let insertAt = 0;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].startsWith('import ') || lines[i].startsWith('<script')) {
+        insertAt = i + 1;
+      }
+    }
+    if (insertAt === 0) {
+      lines.unshift(importStatement);
+    } else {
+      lines.splice(insertAt, 0, importStatement);
+    }
+    updated = lines.join('\n');
+  }
+
+  writeFileSync(filePath, updated, 'utf-8');
+  print({ ok: true, file: filePath });
+}
+
+export async function run(argv: string[]) {
+  const { positional, flags } = parseArgs(argv);
+  const command = positional[0];
+
+  if (!command) {
+    console.error('Usage: reicon-mcp <search|view|apply|categories> [args]');
+    process.exit(1);
+  }
+
+  switch (command) {
+    case 'search': {
+      const query = positional.slice(1).join(' ');
+      if (!query) {
+        console.error('Usage: reicon-mcp search <query>');
+        process.exit(1);
+      }
+      const result = handleSearchIcons({
+        query,
+        weight: flags.weight as IconWeight | undefined,
+        limit: flags.limit ? Number(flags.limit) : undefined,
+      });
+      print(result);
+      if ('error' in result) process.exit(1);
+      break;
+    }
+    case 'view': {
+      const name = positional[1];
+      if (!name) {
+        console.error('Usage: reicon-mcp view <name> --weight Outline|Filled');
+        process.exit(1);
+      }
+      const weight = (flags.weight as IconWeight) || 'Outline';
+      const result = handleViewIcon({ name, weight });
+      print(result);
+      if ('error' in result) process.exit(1);
+      break;
+    }
+    case 'apply': {
+      const name = positional[1];
+      if (!name) {
+        console.error('Usage: reicon-mcp apply <name> --framework react|vue|svelte|html|svg');
+        process.exit(1);
+      }
+      const framework = (flags.framework as Framework) || 'react';
+      const weight = (flags.weight as IconWeight) || 'Outline';
+      const result = handleApplyIcon({
+        name,
+        weight,
+        framework,
+        size: flags.size ? Number(flags.size) : undefined,
+        color: flags.color,
+        componentName: flags.componentName,
+      });
+      if ('error' in result) {
+        print(result);
+        process.exit(1);
+      }
+      if (flags.file && flags.marker) {
+        applyToFile(flags.file, flags.marker, result.importStatement, result.usageSnippet);
+      } else {
+        print(result);
+      }
+      break;
+    }
+    case 'categories': {
+      print(handleListCategories());
+      break;
+    }
+    default:
+      console.error(`Unknown command: ${command}`);
+      process.exit(1);
+  }
+}

--- a/packages/reicon-mcp/src/core/codegen.ts
+++ b/packages/reicon-mcp/src/core/codegen.ts
@@ -1,0 +1,102 @@
+import type { ApplyIconInput, ApplyIconOutput, IconEntry, IconWeight } from './types.js';
+
+function weightProp(weight: IconWeight, framework: ApplyIconInput['framework']): string {
+  if (weight === 'Outline') return '';
+  if (framework === 'html') return ' weight="filled"';
+  return ` weight="${weight}"`;
+}
+
+function sizeProp(size: number, framework: ApplyIconInput['framework']): string {
+  if (framework === 'vue') return ` :size="${size}"`;
+  if (framework === 'html') return ` size="${size}"`;
+  if (framework === 'svelte' || framework === 'react') return ` size={${size}}`;
+  return ` width="${size}" height="${size}"`;
+}
+
+function colorProp(color: string, framework: ApplyIconInput['framework']): string {
+  if (framework === 'vue') return ` color="${color}"`;
+  if (framework === 'html') return ` color="${color}"`;
+  if (framework === 'svelte' || framework === 'react') {
+    const val = color === 'currentColor' ? 'currentColor' : `"${color}"`;
+    return ` color={${val}}`;
+  }
+  return ` color="${color}"`;
+}
+
+export function generateCode(
+  icon: IconEntry,
+  input: ApplyIconInput,
+): ApplyIconOutput | { error: string } {
+  const size = input.size ?? 24;
+  const color = input.color ?? 'currentColor';
+  const component = input.componentName ?? icon.pascal;
+  const weight = input.weight;
+  const weightData = icon.weights[weight];
+  const hasColor = input.color !== undefined;
+
+  if (!weightData) {
+    return { error: `Icon "${icon.name}" does not have a ${weight} weight.` };
+  }
+
+  const colorAttr = (framework: ApplyIconInput['framework']) =>
+    hasColor ? colorProp(color, framework) : '';
+
+  switch (input.framework) {
+    case 'react': {
+      const importStatement = `import { ${component} } from 'reicon-react';`;
+      const props = [
+        sizeProp(size, 'react'),
+        colorAttr('react'),
+        weightProp(weight, 'react'),
+      ].join('');
+      const usageSnippet = `<${component}${props} />`;
+      return { importStatement, usageSnippet };
+    }
+    case 'vue': {
+      const importStatement = `import { ${component} } from 'reicon-vue';`;
+      const props = [
+        sizeProp(size, 'vue'),
+        colorAttr('vue'),
+        weightProp(weight, 'vue'),
+      ].join('');
+      const usageSnippet = `<${component}${props} />`;
+      return { importStatement, usageSnippet };
+    }
+    case 'svelte': {
+      const importStatement = `import { ${component} } from 'reicon-svelte';`;
+      const props = [
+        sizeProp(size, 'svelte'),
+        colorAttr('svelte'),
+        weightProp(weight, 'svelte'),
+      ].join('');
+      const usageSnippet = `<${component}${props} />`;
+      return { importStatement, usageSnippet };
+    }
+    case 'html': {
+      const importStatement = '<script src="https://unpkg.com/reicon/cdn/reicon.min.js"></script>';
+      const props = [
+        ` icon="${icon.name}"`,
+        sizeProp(size, 'html'),
+        colorAttr('html'),
+        weightProp(weight, 'html'),
+      ].join('');
+      const usageSnippet = `<re-icon${props}></re-icon>`;
+      return { importStatement, usageSnippet };
+    }
+    case 'svg': {
+      const importStatement = '';
+      const usageSnippet = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="${weightData.viewBox}" fill="none">${weightData.code}</svg>`;
+      return { importStatement, usageSnippet };
+    }
+    default:
+      return { error: `Unknown framework: ${input.framework}` };
+  }
+}
+
+export function buildSvgMarkup(icon: IconEntry, weight: IconWeight): string | { error: string } {
+  const weightData = icon.weights[weight];
+  if (!weightData) {
+    return { error: `Icon "${icon.name}" does not have a ${weight} weight.` };
+  }
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${weightData.viewBox}" fill="none">${weightData.code}</svg>`;
+}

--- a/packages/reicon-mcp/src/core/index-builder.ts
+++ b/packages/reicon-mcp/src/core/index-builder.ts
@@ -1,0 +1,79 @@
+import type { IconEntry, IconIndex, IconWeight } from './types.js';
+
+const W_KEYS: IconWeight[] = ['Outline', 'Filled'];
+
+const SEARCH_ALIASES: Record<string, string[]> = {
+  x: ['close', 'dismiss', 'cancel'],
+  cart: ['shopping cart', 'shopping'],
+  trash: ['delete', 'remove', 'bin'],
+  settings: ['gear', 'cog'],
+  search: ['magnifier', 'find'],
+  user: ['profile', 'account', 'avatar'],
+  heart: ['love', 'favorite', 'like'],
+};
+
+function toPascalCase(str: string): string {
+  return str
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+}
+
+function stripSvgWrapper(code: string): string {
+  if (!code) return '';
+  return code.replace(/^<svg[^>]*>/, '').replace(/<\/svg>\s*$/, '').trim();
+}
+
+function rewriteColors(svg: string): string {
+  return svg.replace(/fill="white"/g, 'fill="currentColor"');
+}
+
+export function buildIconIndex(data: {
+  categories?: Record<string, { icons?: Record<string, { description?: string[]; weights?: Record<string, { code?: string }> }> }>;
+}): IconIndex {
+  const icons: IconEntry[] = [];
+  const categorySet = new Set<string>();
+  const pascalLowerSet = new Set<string>();
+
+  for (const [catKey, catData] of Object.entries(data.categories || {})) {
+    categorySet.add(catKey);
+
+    for (const [iconKey, icon] of Object.entries(catData.icons || {})) {
+      let pascal = toPascalCase(iconKey);
+
+      if (pascalLowerSet.has(pascal.toLowerCase())) {
+        pascal += toPascalCase(catKey);
+      }
+      pascalLowerSet.add(pascal.toLowerCase());
+
+      const weights: IconEntry['weights'] = {};
+
+      for (const wName of W_KEYS) {
+        const wData = icon.weights?.[wName];
+        if (wData?.code) {
+          weights[wName] = {
+            code: rewriteColors(stripSvgWrapper(wData.code)),
+            viewBox: '0 0 24 24',
+          };
+        }
+      }
+
+      if (Object.keys(weights).length > 0) {
+        icons.push({
+          name: iconKey,
+          pascal,
+          category: catKey,
+          tags: [...(icon.description || []), ...(SEARCH_ALIASES[iconKey] || [])],
+          weights,
+        });
+      }
+    }
+  }
+
+  icons.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    icons,
+    categories: [...categorySet].sort(),
+  };
+}

--- a/packages/reicon-mcp/src/core/load-index.ts
+++ b/packages/reicon-mcp/src/core/load-index.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import type { IconIndex } from './types.js';
+
+let cached: IconIndex | null = null;
+
+function resolveIndexPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, '..', 'data', 'icon-index.json'),
+    join(here, '..', '..', 'src', 'data', 'icon-index.json'),
+  ];
+  for (const p of candidates) {
+    try {
+      readFileSync(p, 'utf-8');
+      return p;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error('icon-index.json not found. Run npm run build:mcp first.');
+}
+
+export function loadIndex(): IconIndex {
+  if (cached) return cached;
+  const path = resolveIndexPath();
+  cached = JSON.parse(readFileSync(path, 'utf-8')) as IconIndex;
+  return cached;
+}

--- a/packages/reicon-mcp/src/core/search.ts
+++ b/packages/reicon-mcp/src/core/search.ts
@@ -1,0 +1,149 @@
+import type { IconEntry, IconIndex, IconWeight, SearchResult } from './types.js';
+
+const SENTENCE_MARKERS = /\?|!|\.{2,}/;
+const SENTENCE_WORDS = /\b(please|could|would|want|need|show|find|give|get|me|my|the|a|an|icon for|looking for|i am|i'm|can you|help me)\b/i;
+
+const SYNONYMS: Record<string, string[]> = {
+  close: ['x'],
+  cart: ['cart', 'cart-large', 'shopping-cart2'],
+  'shopping cart': ['cart', 'cart3', 'shopping-cart2', 'cart-large'],
+  delete: ['trash', 'trash-bin-trash'],
+  remove: ['trash', 'x'],
+  settings: ['settings', 'settings-minimalistic'],
+  arrow: ['arrow-right', 'arrow-down', 'arrow-up', 'arrow-left'],
+  search: ['search', 'minimalistic-magnifer'],
+  heart: ['heart', 'heart-angle'],
+  trash: ['trash', 'trash-bin-trash'],
+  user: ['user', 'user-circle'],
+};
+
+function normalize(text: string): string {
+  return text.toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+function tokenize(text: string): string[] {
+  return normalize(text).split(' ').filter(Boolean);
+}
+
+export function isSentenceQuery(query: string): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return true;
+  if (SENTENCE_MARKERS.test(trimmed)) return true;
+  const words = tokenize(trimmed);
+  if (words.length > 6) return true;
+  if (words.length >= 4 && SENTENCE_WORDS.test(trimmed)) return true;
+  if (/^(how|what|where|which|why|when)\b/i.test(trimmed)) return true;
+  return false;
+}
+
+function synonymBoost(query: string, name: string): number {
+  const key = normalize(query);
+  const list = SYNONYMS[key];
+  if (!list) return 0;
+  const idx = list.indexOf(name);
+  if (idx === -1) return 0;
+  return 3000 - idx * 100;
+}
+
+function scoreIcon(icon: IconEntry, query: string, tokens: string[], weight?: IconWeight): number {
+  const q = normalize(query);
+  const name = icon.name;
+  const nameNorm = name.replace(/-/g, ' ');
+  const tagsNorm = icon.tags.map((t) => normalize(t));
+  let score = 0;
+
+  score += synonymBoost(query, name);
+
+  if (name === q || name === q.replace(/ /g, '-')) {
+    score += 10000;
+  }
+
+  if (tokens.length === 1 && name === tokens[0]) {
+    score += 5000;
+  }
+
+  if (tokens.every((t) => name.includes(t) || nameNorm.includes(t))) {
+    score += 2000;
+  }
+
+  if (tagsNorm.some((t) => t === q)) {
+    score += 1500;
+  }
+
+  for (const token of tokens) {
+    if (tagsNorm.some((t) => t === token)) score += 800;
+    if (name.includes(token)) score += 600;
+    if (tagsNorm.some((t) => t.includes(token))) score += 300;
+  }
+
+  if (tokens.length === 1 && name.startsWith(tokens[0])) {
+    score += 400;
+  }
+
+  score += Math.max(0, 50 - name.length);
+
+  if (weight) {
+    if (icon.weights[weight]) score += 10;
+    else score -= 1000;
+  }
+
+  return score;
+}
+
+export function searchIcons(
+  index: IconIndex,
+  query: string,
+  options: { weight?: IconWeight; limit?: number } = {},
+): { results: SearchResult[]; instruction: string } | { error: string } {
+  if (isSentenceQuery(query)) {
+    return {
+      error: 'Query looks like a full sentence. Use concise keywords instead, such as "cart", "user", or "settings".',
+    };
+  }
+
+  const limit = options.limit ?? 5;
+  const tokens = tokenize(query);
+  const weights: IconWeight[] = options.weight ? [options.weight] : ['Outline', 'Filled'];
+  const results: SearchResult[] = [];
+
+  for (const icon of index.icons) {
+    for (const weight of weights) {
+      if (!icon.weights[weight]) continue;
+      const score = scoreIcon(icon, query, tokens, weight);
+      if (score > 0) {
+        results.push({
+          name: icon.name,
+          weight,
+          category: icon.category,
+          tags: icon.tags,
+          score,
+        });
+      }
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score || a.name.length - b.name.length);
+
+  const seen = new Set<string>();
+  const deduped: SearchResult[] = [];
+  for (const r of results) {
+    const key = `${r.name}:${r.weight}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(r);
+    if (deduped.length >= limit) break;
+  }
+
+  return {
+    results: deduped,
+    instruction: 'Pick exactly one result from the list above and proceed with view_icon or apply_icon. Do not ask a person to choose.',
+  };
+}
+
+export function findIcon(index: IconIndex, name: string): IconEntry | undefined {
+  return index.icons.find((i) => i.name === name);
+}
+
+export function listCategories(index: IconIndex): string[] {
+  return index.categories;
+}

--- a/packages/reicon-mcp/src/core/types.ts
+++ b/packages/reicon-mcp/src/core/types.ts
@@ -1,0 +1,43 @@
+export type IconWeight = 'Outline' | 'Filled';
+
+export type Framework = 'react' | 'vue' | 'svelte' | 'html' | 'svg';
+
+export interface IconWeightData {
+  code: string;
+  viewBox: string;
+}
+
+export interface IconEntry {
+  name: string;
+  pascal: string;
+  category: string;
+  tags: string[];
+  weights: Partial<Record<IconWeight, IconWeightData>>;
+}
+
+export interface IconIndex {
+  icons: IconEntry[];
+  categories: string[];
+}
+
+export interface SearchResult {
+  name: string;
+  weight: IconWeight;
+  category: string;
+  tags: string[];
+  score: number;
+}
+
+export interface ApplyIconInput {
+  name: string;
+  weight: IconWeight;
+  framework: Framework;
+  size?: number;
+  color?: string;
+  componentName?: string;
+}
+
+export interface ApplyIconOutput {
+  importStatement: string;
+  usageSnippet: string;
+}

--- a/packages/reicon-mcp/src/server/index.ts
+++ b/packages/reicon-mcp/src/server/index.ts
@@ -1,0 +1,84 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { handleApplyIcon } from './tools/apply-icon.js';
+import { handleListCategories } from './tools/list-categories.js';
+import { handleSearchIcons } from './tools/search-icons.js';
+import { handleViewIcon } from './tools/view-icon.js';
+
+const server = new McpServer({
+  name: 'reicon-mcp',
+  version: '1.0.0',
+});
+
+server.tool(
+  'search_icons',
+  'Search Reicon icons by keyword. Returns ranked matches for agent selection.',
+  {
+    query: z.string().describe('Concise search keywords, not full sentences'),
+    weight: z.enum(['Outline', 'Filled']).optional(),
+    limit: z.number().optional(),
+  },
+  async (args) => {
+    const result = handleSearchIcons(args);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  'view_icon',
+  'View raw SVG markup and metadata for a Reicon icon.',
+  {
+    name: z.string().describe('Icon kebab-case name'),
+    weight: z.enum(['Outline', 'Filled']),
+  },
+  async (args) => {
+    const result = handleViewIcon(args);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  'apply_icon',
+  'Generate copy-pasteable import and usage code for a Reicon icon.',
+  {
+    name: z.string(),
+    weight: z.enum(['Outline', 'Filled']),
+    framework: z.enum(['react', 'vue', 'svelte', 'html', 'svg']),
+    size: z.number().optional(),
+    color: z.string().optional(),
+    componentName: z.string().optional(),
+  },
+  async (args) => {
+    const result = handleApplyIcon(args);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  'list_categories',
+  'List all icon categories in the Reicon dataset.',
+  {},
+  async () => {
+    const result = handleListCategories();
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/reicon-mcp/src/server/tools/apply-icon.ts
+++ b/packages/reicon-mcp/src/server/tools/apply-icon.ts
@@ -1,0 +1,14 @@
+import { generateCode } from '../../core/codegen.js';
+import { loadIndex } from '../../core/load-index.js';
+import { findIcon } from '../../core/search.js';
+import type { ApplyIconInput } from '../../core/types.js';
+
+export function handleApplyIcon(args: ApplyIconInput) {
+  const index = loadIndex();
+  const icon = findIcon(index, args.name);
+  if (!icon) {
+    return { error: `Icon "${args.name}" not found.` };
+  }
+
+  return generateCode(icon, args);
+}

--- a/packages/reicon-mcp/src/server/tools/list-categories.ts
+++ b/packages/reicon-mcp/src/server/tools/list-categories.ts
@@ -1,0 +1,7 @@
+import { loadIndex } from '../../core/load-index.js';
+import { listCategories } from '../../core/search.js';
+
+export function handleListCategories() {
+  const index = loadIndex();
+  return { categories: listCategories(index) };
+}

--- a/packages/reicon-mcp/src/server/tools/search-icons.ts
+++ b/packages/reicon-mcp/src/server/tools/search-icons.ts
@@ -1,0 +1,15 @@
+import { loadIndex } from '../../core/load-index.js';
+import { searchIcons } from '../../core/search.js';
+import type { IconWeight } from '../../core/types.js';
+
+export function handleSearchIcons(args: {
+  query: string;
+  weight?: IconWeight;
+  limit?: number;
+}) {
+  const index = loadIndex();
+  return searchIcons(index, args.query, {
+    weight: args.weight,
+    limit: args.limit,
+  });
+}

--- a/packages/reicon-mcp/src/server/tools/view-icon.ts
+++ b/packages/reicon-mcp/src/server/tools/view-icon.ts
@@ -1,0 +1,26 @@
+import { buildSvgMarkup } from '../../core/codegen.js';
+import { loadIndex } from '../../core/load-index.js';
+import { findIcon } from '../../core/search.js';
+import type { IconWeight } from '../../core/types.js';
+
+export function handleViewIcon(args: { name: string; weight: IconWeight }) {
+  const index = loadIndex();
+  const icon = findIcon(index, args.name);
+  if (!icon) {
+    return { error: `Icon "${args.name}" not found.` };
+  }
+
+  const svg = buildSvgMarkup(icon, args.weight);
+  if (typeof svg !== 'string') {
+    return svg;
+  }
+
+  const weightData = icon.weights[args.weight]!;
+
+  return {
+    svg,
+    viewBox: weightData.viewBox,
+    tags: icon.tags,
+    category: icon.category,
+  };
+}

--- a/packages/reicon-mcp/tsconfig.json
+++ b/packages/reicon-mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/data/icon-index.json"]
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,6 +17,7 @@
 - [Vanilla HTML/CDN Guide](https://reicon.dev/usage/vanilla): How to load Reicon via unpkg CDN and use custom element `<re-icon>`.
 - [Figma Plugin](https://reicon.dev/usage/figma): How to use Reicon inside Figma.
 - [VS Code Extension](https://reicon.dev/usage/vscode): Productivity extension for Reicon.
+- [MCP Server](https://reicon.dev/usage/mcp): Agent-facing MCP server and CLI for icon search and code generation (`reicon-mcp`).
 - [Raw SVG Assets](https://reicon.dev/usage/svg): Downloading and using raw SVG paths.
 
 ## References

--- a/scripts/seo/config.mjs
+++ b/scripts/seo/config.mjs
@@ -91,6 +91,13 @@ export const ROUTES = [
     changefreq: 'monthly',
   },
   {
+    path: '/usage/mcp',
+    title: 'MCP Server Guide — Reicon | Agent Icon Search and Codegen',
+    description: 'Use the reicon-mcp server to let AI agents search, preview, and apply Reicon icons via MCP or CLI.',
+    priority: '0.8',
+    changefreq: 'monthly',
+  },
+  {
     path: '/usage/svg',
     title: 'Raw SVG Assets Guide — Reicon | Embed & Style SVG Files',
     description: 'Download and use raw Reicon SVG icons in HTML, static layouts, or CMS templates. Customize with CSS currentColor.',
@@ -221,5 +228,5 @@ export const GLOBAL_JSON_LD = [
 export const VOLATILE_ROUTES = new Set([
   '/', '/icons', '/usage', '/usage/react', '/usage/react-native',
   '/usage/vue', '/usage/svelte', '/usage/vanilla', '/usage/figma',
-  '/usage/vscode', '/usage/svg', '/packages', '/pack',
+  '/usage/vscode', '/usage/mcp', '/usage/svg', '/packages', '/pack',
 ]);

--- a/src/components/usage/framework/constants.tsx
+++ b/src/components/usage/framework/constants.tsx
@@ -6,6 +6,7 @@ export const FRAMEWORKS = [
     { id: 'svelte', label: 'Svelte', icon: 'svelte', color: '#FF3E00' },
     { id: 'figma', label: 'Figma', icon: 'figma', color: '#F24E1E' },
     { id: 'vscode', label: 'VS Code', icon: 'vscode', color: '#007ACC' },
+    { id: 'mcp', label: 'MCP Server', icon: 'mcp', color: '#6C5CE7' },
     { id: 'svg', label: 'Raw SVGs', icon: 'svg', color: '#4285F4' },
 ] as const;
 

--- a/src/components/usage/framework/helpers.ts
+++ b/src/components/usage/framework/helpers.ts
@@ -8,6 +8,7 @@ export function getFrameworkSectionId(framework: Framework): string {
     case 'svelte': return 'svelte-usage';
     case 'figma': return 'figma';
     case 'vscode': return 'vscode';
+    case 'mcp': return 'mcp';
     case 'svg': return 'svg-usage';
     default: return 'cdn';
   }
@@ -21,11 +22,12 @@ export function getFrameworkLabel(framework: Framework): string {
     case 'svelte': return 'Svelte';
     case 'figma': return 'Figma';
     case 'vscode': return 'VS Code';
+    case 'mcp': return 'MCP Server';
     case 'svg': return 'Raw SVGs';
     default: return 'Vanilla JS / CDN';
   }
 }
 
 export function isStandaloneFramework(framework: Framework): boolean {
-  return framework === 'figma' || framework === 'vscode' || framework === 'svg';
+  return framework === 'figma' || framework === 'vscode' || framework === 'mcp' || framework === 'svg';
 }

--- a/src/components/usage/framework/icons.tsx
+++ b/src/components/usage/framework/icons.tsx
@@ -34,6 +34,13 @@ export const FigmaIcon = ({ size = 16 }: { size?: number }) => (
     </svg>
 );
 
+export const McpIcon = ({ size = 16 }: { size?: number }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+        <path d="M12 2L3 7V17L12 22L21 17V7L12 2Z" stroke="#6C5CE7" strokeWidth="1.5" strokeLinejoin="round" />
+        <path d="M12 8V16M8 10V14M16 10V14" stroke="#6C5CE7" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+);
+
 export const SvgIcon = ({ size = 16 }: { size?: number }) => (
     <svg width={size} height={size} viewBox="0 0 300 300">
         <g stroke="#000" strokeWidth="38.009">
@@ -55,6 +62,7 @@ export const FrameworkIcon = ({ id, size = 16 }: { id: string; size?: number }) 
     if (id === 'svelte') return <SvelteIcon size={size} />;
     if (id === 'figma') return <FigmaIcon size={size} />;
     if (id === 'vscode') return <VscVscodeInsiders className="text-[#007ACC]" size={size} />;
+    if (id === 'mcp') return <McpIcon size={size} />;
     if (id === 'svg') return <SvgIcon size={size} />;
     return <IoLogoJavascript className="text-yellow-400" size={size} />;
 };

--- a/src/pages/Usage.tsx
+++ b/src/pages/Usage.tsx
@@ -20,6 +20,7 @@ import SvelteUsage from './usage/SvelteUsage';
 import CdnUsage from './usage/CdnUsage';
 import FigmaUsage from './usage/FigmaUsage';
 import VscodeUsage from './usage/VscodeUsage';
+import McpUsage from './usage/McpUsage';
 import SvgUsage from './usage/SvgUsage';
 import PropsTable from './usage/PropsTable';
 import Weights from './usage/Weights';
@@ -36,6 +37,7 @@ import vueDocs from '../../docs/vue/usage.md?raw';
 import svelteDocs from '../../docs/svelte/usage.md?raw';
 import figmaDocs from '../../docs/figma/usage.md?raw';
 import vscodeDocs from '../../docs/vscode/usage.md?raw';
+import mcpDocs from '../../docs/mcp/usage.md?raw';
 import svgDocs from '../../docs/svg/usage.md?raw';
 import propsDocs from '../../docs/shared/props.md?raw';
 import weightsDocs from '../../docs/shared/weights.md?raw';
@@ -356,6 +358,8 @@ export default function UsagePage() {
               <FigmaUsage markdownContent={figmaDocs} />
             ) : framework === 'vscode' ? (
               <VscodeUsage markdownContent={vscodeDocs} copiedField={copiedField} onCopy={copyToClipboard} />
+            ) : framework === 'mcp' ? (
+              <McpUsage markdownContent={mcpDocs} copiedField={copiedField} onCopy={copyToClipboard} />
             ) : framework === 'svg' ? (
               <SvgUsage markdownContent={svgDocs} copiedField={copiedField} onCopy={copyToClipboard} />
             ) : (

--- a/src/pages/packages/data.tsx
+++ b/src/pages/packages/data.tsx
@@ -1,7 +1,7 @@
 import { FaReact } from 'react-icons/fa';
 import { IoLogoJavascript } from 'react-icons/io5';
 import { VscVscodeInsiders } from 'react-icons/vsc';
-import { FigmaIcon, SvelteIcon, VueIcon, SvgIcon } from '../../components/usage/framework/icons';
+import { FigmaIcon, McpIcon, SvelteIcon, VueIcon, SvgIcon } from '../../components/usage/framework/icons';
 
 export interface PackageItem {
     id: string;
@@ -101,6 +101,17 @@ export const TOOLS: ToolItem[] = [
         guideUrl: '/usage/vscode',
         primaryAction: { label: 'Use', href: 'https://marketplace.visualstudio.com/items?itemName=DevChauhan.reicon' },
         sourceUrl: 'https://github.com/dqev/reicon/tree/main/packages/reicon-vscode',
+    },
+    {
+        id: 'mcp',
+        name: 'reicon-mcp',
+        badge: { label: 'MCP Server', color: '#6C5CE7' },
+        version: 'v1.0.0',
+        description: 'Search, preview, and apply Reicon icons from AI agents and automation tools via MCP or CLI.',
+        icon: <McpIcon size={48} />,
+        guideUrl: '/usage/mcp',
+        primaryAction: { label: 'Guide', href: '/usage/mcp' },
+        sourceUrl: 'https://github.com/dqev/reicon/tree/main/packages/reicon-mcp',
     },
 ];
 

--- a/src/pages/usage/McpUsage.tsx
+++ b/src/pages/usage/McpUsage.tsx
@@ -1,0 +1,98 @@
+import SectionHeader from '../../components/usage/SectionHeader';
+import SyntaxBlock from '../../components/usage/SyntaxBlock';
+import { McpIcon } from '../../components/usage/framework/icons';
+
+interface Props {
+  markdownContent: string;
+  copiedField: string | null;
+  onCopy: (text: string, field: string) => void;
+}
+
+const MCP_CONFIG = `{
+  "mcpServers": {
+    "reicon": {
+      "command": "npx",
+      "args": ["reicon-mcp"]
+    }
+  }
+}`;
+
+export default function McpUsage({ markdownContent, copiedField, onCopy }: Props) {
+  return (
+    <section id="mcp" className="mb-16 scroll-mt-24">
+      <SectionHeader
+        id="mcp"
+        title="MCP Server"
+        level="h2"
+        markdownContent={markdownContent}
+        icon={<McpIcon size={30} />}
+      />
+
+      <p className="text-text-base/60 text-[15px] leading-[1.8] mb-6">
+        The <code className="text-text-base/70 bg-text-base/6 px-1.5 py-0.5 rounded text-[12px]">reicon-mcp</code> package exposes Reicon icons to AI agents through the Model Context Protocol. Agents can search, preview SVG markup, and generate copy-pasteable code snippets without human input.
+      </p>
+
+      <div className="mt-8 border-b border-text-base/6 pb-4">
+        <h3 className="text-xl font-serif text-text-base mb-2">1. Installation</h3>
+        <p className="text-text-base/60 text-[15px] leading-[1.8]">
+          Install from npm or build from the monorepo.
+        </p>
+      </div>
+
+      <div className="bg-text-base/3 rounded-2xl p-6 border border-text-base/4 mb-8">
+        <SyntaxBlock
+          title="npm"
+          onCopy={() => onCopy('npm install reicon-mcp', 'mcp-install')}
+          copied={copiedField === 'mcp-install'}
+        >
+          <span className="text-[#98c379]">npm install</span>
+          <span className="text-text-base/70"> reicon-mcp</span>
+        </SyntaxBlock>
+      </div>
+
+      <div className="mt-10 mb-6 border-b border-text-base/6 pb-4">
+        <h3 className="text-xl font-serif text-text-base mb-2">2. MCP Configuration</h3>
+        <p className="text-text-base/60 text-[15px] leading-[1.8]">
+          Add the server to your MCP client. With no arguments, <code className="text-text-base/70 bg-text-base/6 px-1.5 py-0.5 rounded text-[12px]">reicon-mcp</code> starts a stdio MCP server.
+        </p>
+      </div>
+
+      <div className="bg-text-base/3 rounded-2xl p-6 border border-text-base/4 mb-8">
+        <SyntaxBlock
+          title="MCP config"
+          onCopy={() => onCopy(MCP_CONFIG, 'mcp-config')}
+          copied={copiedField === 'mcp-config'}
+        >
+          <span className="text-text-base/70">{MCP_CONFIG}</span>
+        </SyntaxBlock>
+      </div>
+
+      <div className="mt-10 mb-6 border-b border-text-base/6 pb-4">
+        <h3 className="text-xl font-serif text-text-base mb-2">3. CLI Usage</h3>
+        <p className="text-text-base/60 text-[15px] leading-[1.8]">
+          The same binary supports CLI mode when arguments are provided.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <SyntaxBlock
+          title="Search"
+          onCopy={() => onCopy('npx reicon-mcp search "shopping cart"', 'mcp-search')}
+          copied={copiedField === 'mcp-search'}
+        >
+          <span className="text-[#98c379]">npx reicon-mcp search</span>
+          <span className="text-text-base/70"> "shopping cart"</span>
+        </SyntaxBlock>
+
+        <SyntaxBlock
+          title="Apply"
+          onCopy={() => onCopy('npx reicon-mcp apply heart --framework react --size 32 --color "#ef4444"', 'mcp-apply')}
+          copied={copiedField === 'mcp-apply'}
+        >
+          <span className="text-[#98c379]">npx reicon-mcp apply</span>
+          <span className="text-text-base/70"> heart --framework react --size 32 --color "#ef4444"</span>
+        </SyntaxBlock>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds `reicon-mcp`, an MCP server and CLI that lets agents search, preview, and apply Reicon icons without human input.

## Related issue

## Type of change

- [ ] New icon(s)
- [ ] Icon fix (alignment / stroke / grid)
- [ ] Bug fix
- [x] Feature / enhancement
- [x] Documentation
- [x] Chore / tooling

## Checklist

- [x] Branch is up to date with `main`.
- [x] `npm run sync:icons` was run after editing `data/icon-data.json`.
- [x] `npm run validate:icons` reports in sync.
- [x] `npm run lint` passes (no type errors).
- [x] Icons are on a 24x24 grid, use `currentColor`, paths are SVGO-optimised.
- [x] **I did NOT run `npm run build:packages`** — package releases are handled by the maintainer.

## Details

The new package includes four MCP tools (`search_icons`, `view_icon`, `apply_icon`, `list_categories`) and a matching CLI. Search uses a prebuilt index from `icon-data.json` with no runtime network calls. `apply_icon` returns copy-pasteable snippets for React, Vue, Svelte, HTML (`<re-icon>`), and raw SVG. The CLI also supports bounded file insertion via `--file` and `--marker` for scripted use.

Wired into `npm run build:packages` via `build:mcp`. Added usage docs at `docs/mcp/usage.md`, a site page at `/usage/mcp`, and updated README and `public/llms.txt`.