### PR TITLE
fix(reicon-react): add 'use client' directive to generated icon files

### DIFF
--- a/packages/reicon-react/scripts/build.cjs
+++ b/packages/reicon-react/scripts/build.cjs
@@ -122,7 +122,8 @@ for (const icon of icons) {
   const kebab = icon.kebab;
 
   // ── icon .js file with JSDoc ──
-  const iconJS = `import createIcon from '../createIcon.js';
+  const iconJS = `'use client';
+import createIcon from '../createIcon.js';
 
 /**
  * @component


### PR DESCRIPTION
## Problem
Importing a reicon-react icon directly into a Next.js App Router Server
Component throws a runtime error because generated icon files
(src/icons/*.js) call createIcon() — which is marked 'use client' in
createIcon.js — at module scope, without carrying the directive
themselves.

## Fix
Added 'use client' to the icon-file template in
packages/reicon-react/scripts/build.cjs, so every generated file is
unambiguously part of the client module graph.

## Testing
Reproduced with Next.js 16 App Router + a Server Component exporting
metadata. Verified the error before the fix and its absence after,
using a local npm pack build linked into a real project.