### PR TITLE
fix: resolve CORS issue on illustration

### DIFF
--- a/src/pages/illustration/IllustrationDetail.tsx
+++ b/src/pages/illustration/IllustrationDetail.tsx
@@ -108,18 +108,33 @@ export default function IllustrationDetail() {
   };
 
   const handleDownloadSvg = () => {
+    if (!svgCode) {
+      flashToast('error');
+      return;
+    }
+
+    const blob = new Blob([svgCode], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    
     const a = document.createElement('a');
-    a.href = cdnUrl;
-    a.download = `${currentSlug}.svg`;
-    a.target = '_blank';
+    a.href = url;
+    a.download = `${currentSlug}-${exportSize}x${exportSize}.svg`;
     a.click();
+
+    URL.revokeObjectURL(url);
     flashToast('download-svg');
   };
 
   const handleDownloadPng = async () => {
     try {
+      if (!svgCode) {
+        flashToast('error');
+        return;
+      }
+      const blob = new Blob([svgCode], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+
       const img = new Image();
-      img.crossOrigin = 'anonymous';
       img.onload = () => {
         const canvas = document.createElement('canvas');
         canvas.width = exportSize;
@@ -130,12 +145,13 @@ export default function IllustrationDetail() {
           const pngUrl = canvas.toDataURL('image/png');
           const a = document.createElement('a');
           a.href = pngUrl;
-          a.download = `${currentSlug}.png`;
+          a.download = `${currentSlug}-${exportSize}x${exportSize}.png`;
           a.click();
+          URL.revokeObjectURL(url);
           flashToast('download-png');
         }
       };
-      img.src = cdnUrl;
+      img.src = url;
     } catch {
       flashToast('error');
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Reicon! 💜 Fill out the relevant sections below. -->

## Summary
Resolves the CORS error that blocks PNG/SVG illustration downloads by generating a local `Blob` directly from the `svgCode` state, and updates the exported filenames to accurately reflect the user's selected export size (e.g., `airliner-512x512.png`).

## Related issue
Closes #58 

## Type of change
- [ ] 🎨 New icon(s)
- [ ] ✏️ Icon fix (alignment / stroke / grid)
- [x] 🐛 Bug fix
- [ ] ✨ Feature / enhancement
- [ ] 📖 Documentation
- [ ] 🔧 Chore / tooling

---

## For icon contributions
<!-- Fill this out if you checked "New icon(s)" or "Icon fix" above -->

**Icon name(s):** N/A

**Did you add `"contributor": { "github": "your-username" }` to each new icon?**
- [ ] Yes — my GitHub username is in `data/icon-data.json` next to each new icon
- [x] N/A — this is an icon fix, not a new icon

**Screenshots**

| Outline | Filled |
| ------- | ------ |
|         |        |

---

## Checklist
- [x] Branch is up to date with `main`.
- [ ] `npm run sync:icons` was run after editing `data/icon-data.json`. *(N/A)*
- [ ] `npm run validate:icons` reports ✅ in sync. *(N/A)*
- [x] `npm run lint` passes (no type errors).
- [ ] Icons are on a 24×24 grid, use `currentColor`, paths are SVGO-optimised. *(N/A)*
- [x] **I did NOT run `npm run build:packages`** — package releases are handled by the maintainer.