### PR TITLE
test: fix broken header smoke test due to duplicate navigation links

### DIFF
--- a/src/test/smoke.test.tsx
+++ b/src/test/smoke.test.tsx
@@ -29,7 +29,7 @@ describe('Header smoke test', () => {
         </MemoryRouter>
       </ThemeProvider>,
     );
-    expect(screen.getByText('Icons')).toBeInTheDocument();
+    expect(screen.getAllByText('Icons')[0]).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the `Header smoke test` in `src/test/smoke.test.tsx` which was failing due to `getByText` finding duplicate "Icons" links (desktop + mobile navigation). Updated to use `getAllByText` to resolve the test failure.

## Type of change

- [ ] 🎨 New icon(s)
- [ ] ✏️ Icon fix (alignment / stroke / grid)
- [ ] 🐛 Bug fix
- [ ] ✨ Feature / enhancement
- [ ] 📖 Documentation
- [x] 🔧 Chore / tooling

---

## For icon contributions

<!-- Fill this out if you checked "New icon(s)" or "Icon fix" above -->

**Icon name(s):** N/A

**Did you add `"contributor": { "github": "your-username" }` to each new icon?**

- [ ] Yes — my GitHub username is in `data/icon-data.json` next to each new icon
- [x] N/A — this is an icon fix, not a new icon

**Screenshots**

| Outline | Filled |
| ------- | ------ |
|         |        |

---

## Checklist

- [x] Branch is up to date with `main`.
- [ ] `npm run sync:icons` was run after editing `data/icon-data.json`. *(N/A)*
- [ ] `npm run validate:icons` reports ✅ in sync. *(N/A)*
- [x] `npm run lint` passes (no type errors).
- [ ] Icons are on a 24×24 grid, use `currentColor`, paths are SVGO-optimised. *(N/A)*
- [x] **I did NOT run `npm run build:packages`** — package releases are handled by the maintainer.