### PR TITLE
fix: correct logo download filenames and use cdn proxy for svg

### DIFF
--- a/src/pages/logo/LogoDetail.tsx
+++ b/src/pages/logo/LogoDetail.tsx
@@ -62,20 +62,24 @@ export default function LogoDetail() {
   };
 
   const handleDownloadSvg = () => {
-    if (!logo) return;
+    if (!logo) {
+      flashToast('error');
+      return;
+    }
+    
     const activeUrl = logo.variants[selectedVariant] || getLogoUrl(logo.slug, selectedVariant);
+    const proxyUrl = activeUrl.replace('https://cdn.reicon.dev', '/cdn-proxy');
 
-    fetch(activeUrl)
+    fetch(proxyUrl)
       .then((res) => res.blob())
       .then((blob) => {
-        const url = window.URL.createObjectURL(blob);
+        const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
         a.download = `${logo.slug}-${selectedVariant}.svg`;
         document.body.appendChild(a);
         a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
         flashToast(`Downloaded ${logo.name} SVG!`);
       })
       .catch(() => {
@@ -84,8 +88,14 @@ export default function LogoDetail() {
   };
 
   const handleDownloadRaster = (format: 'png' | 'webp') => {
-    if (!logo) return;
+    if (!logo) {
+      flashToast('error');
+      return;
+    }
+    
     const activeUrl = logo.variants[selectedVariant] || getLogoUrl(logo.slug, selectedVariant);
+    const proxyUrl = activeUrl.replace("https://cdn.reicon.dev", "/cdn-proxy");
+    
     const canvas = document.createElement('canvas');
     canvas.width = exportSize;
     canvas.height = exportSize;
@@ -100,7 +110,7 @@ export default function LogoDetail() {
         const dataUrl = canvas.toDataURL(`image/${format}`);
         const a = document.createElement('a');
         a.href = dataUrl;
-        a.download = `${logo.slug}-${selectedVariant}-${exportSize}px.${format}`;
+        a.download = `${logo.slug}-${selectedVariant}-${exportSize}x${exportSize}.${format}`;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
@@ -108,7 +118,7 @@ export default function LogoDetail() {
       }
     };
 
-    img.src = activeUrl;
+    img.src = proxyUrl;
   };
 
   const handleBack = () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Reicon! 💜 Fill out the relevant sections below. -->

## Summary

Fixes the SVG download in `LogoDetail.tsx` which was blocked by CORS when fetching directly from the CDN. The fix routes the fetch through the Vite dev proxy (`/cdn-proxy`). Also corrects the download filenames — SVG no longer incorrectly includes the export size, and PNG/WEBP now uses the `WxH` dimension format (e.g. `48x48`) consistent with the illustration downloads.

> **Note :** The proxy fix resolves the issue in local development. For production, the logo CDN (`cdn.reicon.dev`) will also need `Access-Control-Allow-Origin` headers added, similar to the illustration CDN.

## Type of change

- [ ] 🎨 New icon(s)
- [ ] ✏️ Icon fix (alignment / stroke / grid)
- [x] 🐛 Bug fix
- [ ] ✨ Feature / enhancement
- [ ] 📖 Documentation
- [ ] 🔧 Chore / tooling

---

## For icon contributions

**Icon name(s):** N/A

**Did you add `"contributor": { "github": "your-username" }` to each new icon?**
- [ ] Yes — my GitHub username is in `data/icon-data.json` next to each new icon
- [x] N/A — this is an icon fix, not a new icon

**Screenshots**

| Outline | Filled |
| ------- | ------ |
|         |        |

---

## Checklist

- [x] Branch is up to date with `main`.
- [ ] `npm run sync:icons` was run after editing `data/icon-data.json`. *(N/A)*
- [ ] `npm run validate:icons` reports ✅ in sync. *(N/A)*
- [x] `npm run lint` passes (no type errors).
- [ ] Icons are on a 24×24 grid, use `currentColor`, paths are SVGO-optimised. *(N/A)*
- [x] **I did NOT run `npm run build:packages`** — package releases are handled by the maintainer.
