### PR TITLE
fix(react): apply strokeWidth to all outline icons

### DIFF
--- a/packages/reicon-react/src/createIcon.d.ts
+++ b/packages/reicon-react/src/createIcon.d.ts
@@ -11,7 +11,7 @@ export interface IconProps extends Omit<SVGAttributes<SVGSVGElement>, 'color'> {
   size?: number | string;
   /** Icon weight / style. Default: `Outline` */
   weight?: IconWeight;
-  /** Override stroke-width on stroked weights */
+  /** Override the visual stroke width of Outline icons. Default: `1.5` */
   strokeWidth?: number | string;
 }
 

--- a/packages/reicon-react/src/createIcon.js
+++ b/packages/reicon-react/src/createIcon.js
@@ -2,6 +2,61 @@
 import { forwardRef, createElement } from 'react';
 
 const W_MAP = { Filled: 'F', Outline: 'O' };
+const DEFAULT_OUTLINE_STROKE_WIDTH = 1.5;
+
+function getNumericStrokeWidth(strokeWidth) {
+  if (typeof strokeWidth === 'number') {
+    return Number.isFinite(strokeWidth) ? Math.max(0, strokeWidth) : null;
+  }
+
+  if (typeof strokeWidth !== 'string' || strokeWidth.trim() === '') {
+    return null;
+  }
+
+  const numericStrokeWidth = Number(strokeWidth);
+  return Number.isFinite(numericStrokeWidth) ? Math.max(0, numericStrokeWidth) : null;
+}
+
+function hashIconHtml(html) {
+  let hash = 2166136261;
+
+  for (let index = 0; index < html.length; index += 1) {
+    hash ^= html.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
+function getStrokeAdjustmentIdPrefix(displayName, html) {
+  const safeDisplayName = displayName.replace(/[^a-zA-Z0-9_-]/g, '-');
+  return `reicon-${safeDisplayName}-${hashIconHtml(html)}`;
+}
+
+function adjustFilledOutline(adjustmentIdPrefix, html, strokeWidth) {
+  const numericStrokeWidth = getNumericStrokeWidth(strokeWidth);
+
+  if (
+    numericStrokeWidth == null ||
+    numericStrokeWidth === DEFAULT_OUTLINE_STROKE_WIDTH
+  ) {
+    return html;
+  }
+
+  const strokeAdjustment = Math.abs(numericStrokeWidth - DEFAULT_OUTLINE_STROKE_WIDTH);
+
+  if (numericStrokeWidth > DEFAULT_OUTLINE_STROKE_WIDTH) {
+    return `<g stroke="currentColor" stroke-width="${strokeAdjustment}" stroke-linecap="round" stroke-linejoin="round" paint-order="stroke fill">${html}</g>`;
+  }
+
+  const safeStrokeWidth = String(numericStrokeWidth).replace(/[^a-zA-Z0-9_-]/g, '-');
+  const adjustmentId = `${adjustmentIdPrefix}-${safeStrokeWidth}`;
+  const sourceId = `${adjustmentId}-source`;
+  const maskId = `${adjustmentId}-mask`;
+  const inheritableHtml = html.replace(/\sfill="currentColor"/g, '');
+
+  return `<defs><g id="${sourceId}">${inheritableHtml}</g><mask id="${maskId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" x="-12" y="-12" width="48" height="48"><use href="#${sourceId}" fill="white"/><use href="#${sourceId}" fill="none" stroke="black" stroke-width="${strokeAdjustment}" stroke-linecap="round" stroke-linejoin="round"/></mask></defs><use href="#${sourceId}" fill="currentColor" mask="url(#${maskId})"/>`;
+}
 
 /**
  * Factory that builds a forwardRef icon component.
@@ -9,6 +64,11 @@ const W_MAP = { Filled: 'F', Outline: 'O' };
  * @param {Object} iconData     { F?: string, O?: string }
  */
 const createIcon = (displayName, iconData) => {
+  const filledOutlineHtml =
+    iconData.O && !iconData.O.includes('stroke-width=') ? iconData.O : null;
+  const strokeAdjustmentIdPrefix = filledOutlineHtml
+    ? getStrokeAdjustmentIdPrefix(displayName, filledOutlineHtml)
+    : null;
   const Icon = forwardRef(
     /**
      * @param {import('./createIcon').IconProps} props
@@ -29,9 +89,15 @@ const createIcon = (displayName, iconData) => {
     ) => {
       const key = W_MAP[weight] || 'O';
       let html = iconData[key] || iconData[Object.keys(iconData)[0]] || '';
+      let inheritedStrokeWidth;
 
-      if (strokeWidth != null) {
-        html = html.replace(/stroke-width="[^"]*"/g, 'stroke-width="' + strokeWidth + '"');
+      if (strokeWidth != null && key === 'O') {
+        if (filledOutlineHtml && strokeAdjustmentIdPrefix) {
+          html = adjustFilledOutline(strokeAdjustmentIdPrefix, filledOutlineHtml, strokeWidth);
+        } else if (html.includes('stroke-width=')) {
+          html = html.replace(/\sstroke-width="[^"]*"/g, '');
+          inheritedStrokeWidth = strokeWidth;
+        }
       }
 
       return createElement('svg', {
@@ -41,6 +107,7 @@ const createIcon = (displayName, iconData) => {
         height: size,
         viewBox: '0 0 24 24',
         fill: 'none',
+        strokeWidth: inheritedStrokeWidth,
         className: className ? 'reicon ' + className : 'reicon',
         style: color != null ? { color, ...style } : style,
         ...rest,


### PR DESCRIPTION
## Summary

Make the React `strokeWidth` prop work across every Outline icon, including the expanded-path artwork where the prop was previously a no-op.

- Preserve the existing output when `strokeWidth` is omitted or set to the `1.5` default.
- Expand or erode filled-path Outline artwork for bold and thin values.
- Keep Filled variants independent of `strokeWidth`.
- Apply native stroke widths through SVG inheritance instead of interpolating the prop into raw icon markup.

## Related issue

Closes #72

## Type of change

- [ ] 🎨 New icon(s)
- [ ] ✏️ Icon fix (alignment / stroke / grid)
- [x] 🐛 Bug fix
- [ ] ✨ Feature / enhancement
- [ ] 📖 Documentation
- [ ] 🔧 Chore / tooling

## Verification

- `npm test`
- `npm run lint`
- `npm run validate:icons`
- `npm run build:react`
- Raster-audited all 2,676 Outline icons at `1`, `1.5`, and `2.5`: all thin variants became lighter, all bold variants became heavier, and no icons became blank.

## Checklist

- [x] Branch is up to date with `main`.
- [x] `npm run sync:icons` is not required because `data/icon-data.json` is unchanged.
- [x] `npm run validate:icons` reports ✅ in sync.
- [x] `npm run lint` passes (no type errors).
- [x] Icons remain on their existing 24×24 grid and continue to use `currentColor`.
- [x] **I did NOT run `npm run build:packages`** — package releases are handled by the maintainer.
