### PR TITLE
fix(react): apply strokeWidth to filled icons

### DIFF
--- a/packages/reicon-react/src/createIcon.d.ts
+++ b/packages/reicon-react/src/createIcon.d.ts
@@ -11,7 +11,7 @@ export interface IconProps extends Omit<SVGAttributes<SVGSVGElement>, 'color'> {
   size?: number | string;
   /** Icon weight / style. Default: `Outline` */
   weight?: IconWeight;
-  /** Override the visual stroke width of Outline icons. Default: `1.5` */
+  /** Override the visual stroke width across icon weights. Default: `1.5` */
   strokeWidth?: number | string;
 }
 

--- a/packages/reicon-react/src/createIcon.js
+++ b/packages/reicon-react/src/createIcon.js
@@ -2,7 +2,7 @@
 import { forwardRef, createElement } from 'react';
 
 const W_MAP = { Filled: 'F', Outline: 'O' };
-const DEFAULT_OUTLINE_STROKE_WIDTH = 1.5;
+const DEFAULT_STROKE_WIDTH = 1.5;
 
 function getNumericStrokeWidth(strokeWidth) {
   if (typeof strokeWidth === 'number') {
@@ -33,19 +33,27 @@ function getStrokeAdjustmentIdPrefix(displayName, html) {
   return `reicon-${safeDisplayName}-${hashIconHtml(html)}`;
 }
 
-function adjustFilledOutline(adjustmentIdPrefix, html, strokeWidth) {
+function getExpandedPathData(displayName, html) {
+  if (!html || html.includes('stroke-width=')) {
+    return null;
+  }
+
+  return {
+    html,
+    strokeAdjustmentIdPrefix: getStrokeAdjustmentIdPrefix(displayName, html),
+  };
+}
+
+function adjustExpandedPaths(adjustmentIdPrefix, html, strokeWidth) {
   const numericStrokeWidth = getNumericStrokeWidth(strokeWidth);
 
-  if (
-    numericStrokeWidth == null ||
-    numericStrokeWidth === DEFAULT_OUTLINE_STROKE_WIDTH
-  ) {
+  if (numericStrokeWidth == null || numericStrokeWidth === DEFAULT_STROKE_WIDTH) {
     return html;
   }
 
-  const strokeAdjustment = Math.abs(numericStrokeWidth - DEFAULT_OUTLINE_STROKE_WIDTH);
+  const strokeAdjustment = Math.abs(numericStrokeWidth - DEFAULT_STROKE_WIDTH);
 
-  if (numericStrokeWidth > DEFAULT_OUTLINE_STROKE_WIDTH) {
+  if (numericStrokeWidth > DEFAULT_STROKE_WIDTH) {
     return `<g stroke="currentColor" stroke-width="${strokeAdjustment}" stroke-linecap="round" stroke-linejoin="round" paint-order="stroke fill">${html}</g>`;
   }
 
@@ -64,11 +72,10 @@ function adjustFilledOutline(adjustmentIdPrefix, html, strokeWidth) {
  * @param {Object} iconData     { F?: string, O?: string }
  */
 const createIcon = (displayName, iconData) => {
-  const filledOutlineHtml =
-    iconData.O && !iconData.O.includes('stroke-width=') ? iconData.O : null;
-  const strokeAdjustmentIdPrefix = filledOutlineHtml
-    ? getStrokeAdjustmentIdPrefix(displayName, filledOutlineHtml)
-    : null;
+  const expandedPathData = {
+    F: getExpandedPathData(displayName, iconData.F),
+    O: getExpandedPathData(displayName, iconData.O),
+  };
   const Icon = forwardRef(
     /**
      * @param {import('./createIcon').IconProps} props
@@ -91,9 +98,15 @@ const createIcon = (displayName, iconData) => {
       let html = iconData[key] || iconData[Object.keys(iconData)[0]] || '';
       let inheritedStrokeWidth;
 
-      if (strokeWidth != null && key === 'O') {
-        if (filledOutlineHtml && strokeAdjustmentIdPrefix) {
-          html = adjustFilledOutline(strokeAdjustmentIdPrefix, filledOutlineHtml, strokeWidth);
+      if (strokeWidth != null) {
+        const expandedPaths = expandedPathData[key];
+
+        if (expandedPaths) {
+          html = adjustExpandedPaths(
+            expandedPaths.strokeAdjustmentIdPrefix,
+            expandedPaths.html,
+            strokeWidth,
+          );
         } else if (html.includes('stroke-width=')) {
           html = html.replace(/\sstroke-width="[^"]*"/g, '');
           inheritedStrokeWidth = strokeWidth;


### PR DESCRIPTION
## Summary

Apply an explicit React `strokeWidth` across both Outline and Filled icon weights.

- Reuse the expanded-path adjustment introduced in #73 for fill-only Filled artwork.
- Apply SVG stroke inheritance to Filled artwork authored with native strokes.
- Preserve the existing output when `strokeWidth` is omitted or set to the `1.5` default.
- Keep the canonical icon data unchanged.

This prevents active-state switches from discarding an explicit visual weight. For example, `Refresh` now has matching bounds and raster ink when switching between Outline and Filled at `strokeWidth={2.5}`.

## Related issue

Closes #74

Follow-up to the original report #72 and fix #73.

## Type of change

- [ ] 🎨 New icon(s)
- [ ] ✏️ Icon fix (alignment / stroke / grid)
- [x] 🐛 Bug fix
- [ ] ✨ Feature / enhancement
- [ ] 📖 Documentation
- [ ] 🔧 Chore / tooling

## Verification

- `npm test`
- `npm run lint`
- `npm run validate:icons`
- `npm run build:react`
- Raster-audited all 2,676 Filled variants at `strokeWidth` values `1`, `1.5`, and `2.5`: no blank icons, every thin variant lost ink, and every bold variant gained ink.
- Confirmed omitted `strokeWidth` and `strokeWidth={1.5}` produce identical output for fill-only Filled variants.

## Checklist

- [x] Branch is up to date with `main`.
- [x] `npm run sync:icons` is not required because `data/icon-data.json` is unchanged.
- [x] `npm run validate:icons` reports ✅ in sync.
- [x] `npm run lint` passes (no type errors).
- [x] Icons remain on their existing 24×24 grid and continue to use `currentColor`.
- [x] **I did NOT run `npm run build:packages`** — package releases are handled by the maintainer.
